### PR TITLE
feat: new error handling

### DIFF
--- a/lib/zoi.ex
+++ b/lib/zoi.ex
@@ -54,30 +54,21 @@ defmodule Zoi do
   alias Zoi.Types.Meta
 
   @type input :: any()
-  @type result :: {:ok, any()} | {:error, map()}
+  @type result :: {:ok, any()} | {:error, [Zoi.Error.t(), ...]}
   @type options :: keyword()
 
   defmodule Error do
     @type t :: %__MODULE__{
-            message: binary(),
-            issues: [binary()]
+            message: binary()
           }
-    defexception [:message, issues: [], path: []]
+    defexception [:message, path: []]
 
     @impl true
     def exception(opts) when is_list(opts) do
       struct!(__MODULE__, opts)
     end
 
-    def add_error(issue) when is_binary(issue) do
-      %__MODULE__{issues: [issue]}
-    end
-
-    def add_error(%__MODULE__{issues: issues} = error, issue) do
-      %{error | issues: issues ++ [issue]}
-    end
-
-    def message(%__MODULE__{issues: issues}), do: Enum.join(issues, ", ")
+    def message(%__MODULE__{message: message}), do: message
   end
 
   @doc """
@@ -103,8 +94,7 @@ defmodule Zoi do
          {:ok, result} <- Meta.run_transforms(schema, result) do
       {:ok, result}
     else
-      {:error, %Zoi.Error{} = error} -> {:error, error}
-      {:error, reason} when is_binary(reason) -> {:error, Zoi.Error.add_error(reason)}
+      {:error, errors} -> {:error, errors}
     end
   end
 

--- a/lib/zoi/refinements.ex
+++ b/lib/zoi/refinements.ex
@@ -5,7 +5,7 @@ defmodule Zoi.Refinements do
     if String.length(input) >= min do
       :ok
     else
-      {:error, "minimum length is #{min}"}
+      {:error, %Zoi.Error{message: "minimum length is #{min}"}}
     end
   end
 
@@ -13,7 +13,7 @@ defmodule Zoi.Refinements do
     if input >= min do
       :ok
     else
-      {:error, "minimum value is #{min}"}
+      {:error, %Zoi.Error{message: "minimum value is #{min}"}}
     end
   end
 
@@ -21,7 +21,7 @@ defmodule Zoi.Refinements do
     if input >= min do
       :ok
     else
-      {:error, "minimum value is #{min}"}
+      {:error, %Zoi.Error{message: "minimum value is #{min}"}}
     end
   end
 
@@ -29,7 +29,7 @@ defmodule Zoi.Refinements do
     if String.length(input) <= max do
       :ok
     else
-      {:error, "maximum length is #{max}"}
+      {:error, %Zoi.Error{message: "maximum length is #{max}"}}
     end
   end
 
@@ -37,7 +37,7 @@ defmodule Zoi.Refinements do
     if input <= max do
       :ok
     else
-      {:error, "maximum value is #{max}"}
+      {:error, %Zoi.Error{message: "maximum value is #{max}"}}
     end
   end
 
@@ -45,7 +45,7 @@ defmodule Zoi.Refinements do
     if input <= max do
       :ok
     else
-      {:error, "maximum value is #{max}"}
+      {:error, %Zoi.Error{message: "maximum value is #{max}"}}
     end
   end
 
@@ -53,7 +53,7 @@ defmodule Zoi.Refinements do
     if String.length(input) == length do
       :ok
     else
-      {:error, "length must be #{length}"}
+      {:error, %Zoi.Error{message: "length must be #{length}"}}
     end
   end
 
@@ -63,7 +63,7 @@ defmodule Zoi.Refinements do
     if String.match?(input, regex) do
       :ok
     else
-      {:error, message}
+      {:error, %Zoi.Error{message: message}}
     end
   end
 
@@ -71,7 +71,7 @@ defmodule Zoi.Refinements do
     if String.starts_with?(input, prefix) do
       :ok
     else
-      {:error, "must start with '#{prefix}'"}
+      {:error, %Zoi.Error{message: "must start with '#{prefix}'"}}
     end
   end
 
@@ -79,7 +79,7 @@ defmodule Zoi.Refinements do
     if String.ends_with?(input, suffix) do
       :ok
     else
-      {:error, "must end with '#{suffix}'"}
+      {:error, %Zoi.Error{message: "must end with '#{suffix}'"}}
     end
   end
 

--- a/lib/zoi/types/object.ex
+++ b/lib/zoi/types/object.ex
@@ -16,7 +16,7 @@ defmodule Zoi.Types.Object do
               # If the field is optional, we skip it and do not add it to parsed
               {parsed, errors}
             else
-              {parsed, Map.put(errors, key, Zoi.Error.add_error("is required"))}
+              {parsed, errors ++ [%Zoi.Error{message: "#{key} is required "}]}
             end
 
           {:ok, value} ->
@@ -25,7 +25,7 @@ defmodule Zoi.Types.Object do
                 {Map.put(parsed, key, val), errors}
 
               {:error, err} ->
-                {parsed, Map.put(errors, key, err)}
+                {parsed, errors ++ [%Zoi.Error{message: "Error on #{key}: #{err.message} "}]}
             end
         end
       end)
@@ -33,13 +33,13 @@ defmodule Zoi.Types.Object do
         if errors == %{} do
           {:ok, parsed}
         else
-          {:error, %Zoi.Error{issues: errors}}
+          {:error, errors}
         end
       end)
     end
 
     def parse(_, _, _) do
-      {:error, Zoi.Error.add_error("invalid object type")}
+      {:error, [%Zoi.Error{message: "invalid object type"}]}
     end
 
     defp map_fetch(map, key) do


### PR DESCRIPTION
This proposal of the new error handling:

- Removes `issues` attribute for `Zoi.Error`, this will be a single error.
- Changes the spec to from `Zoi.parse` to   `@type result :: {:ok, any()} | {:error, [Zoi.Error.t(), ...]}`
- Simplifies the way the refinements and the transformations are run.

How it will look ?

Tested with the following code

```elixir
iex(54)> schema = Zoi.string() |> Zoi.min(8) |> Zoi.length(8) |> Zoi.to_upcase() |> Zoi.transform(fn %Zoi.Types.String{} = _type, input -> if String.graphemes(input) |> Enum.count(& &1 == "A") == 3, do: String.replace(input, "A", "B"), else: {:error, "Too many A"} end)
%Zoi.Types.String{
  coerce: false,
  meta: %Zoi.Types.Meta{
    refinements: [
      {Zoi.Refinements, :refine, [[min: 8], []]},
      {Zoi.Refinements, :refine, [[length: 8], []]}
    ],
    transforms: [
      {Zoi.Transforms, :transform, [[:to_upcase]]},
      #Function<41.81571850/2 in :erl_eval.expr/6>
    ],
    error: nil
  }
}

iex(57)> Zoi.parse(schema, "holallll")
{:error, [%Zoi.Error{message: "Too many A", path: []}]}

iex(60)> Zoi.parse(schema, "hola")
{:error,
 [
   error: %Zoi.Error{message: "minimum length is 8", path: []},
   error: %Zoi.Error{message: "length must be 8", path: []}
 ]}

iex(61)> Zoi.parse(schema, "holaaall")
{:ok, "HOLBBBLL"}
```

TO_DO:
- [ ] Fix tests
