### PR TITLE
refactor all errors to be generated on type creation instead of parsi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.6.2 - Unreleased
+
+### Changed
+
+- Refactor all errors to be generated on type creation instead of parsing time
+- `Zoi.nullable/2` now returns the error message "invalid type: must be a %{type} or nil"
+
 ## 0.6.1 - 2025-09-08
 
 ### Added

--- a/lib/zoi/iso/date.ex
+++ b/lib/zoi/iso/date.ex
@@ -3,6 +3,7 @@ defmodule Zoi.ISO.Date do
   use Zoi.Type.Def
 
   def new(opts \\ []) do
+    opts = Keyword.merge([error: "invalid type: must be an ISO date"], opts)
     apply_type(opts)
   end
 
@@ -22,7 +23,7 @@ defmodule Zoi.ISO.Date do
     end
 
     defp error(schema) do
-      {:error, schema.meta.error || "invalid type: must be an ISO date"}
+      {:error, schema.meta.error}
     end
 
     def type_spec(_schema, _opts) do

--- a/lib/zoi/iso/datetime.ex
+++ b/lib/zoi/iso/datetime.ex
@@ -3,6 +3,7 @@ defmodule Zoi.ISO.DateTime do
   use Zoi.Type.Def
 
   def new(opts \\ []) do
+    opts = Keyword.merge([error: "invalid type: must be an ISO datetime"], opts)
     apply_type(opts)
   end
 
@@ -22,7 +23,7 @@ defmodule Zoi.ISO.DateTime do
     end
 
     defp error(schema) do
-      {:error, schema.meta.error || "invalid type: must be an ISO datetime"}
+      {:error, schema.meta.error}
     end
 
     def type_spec(_schema, _opts) do

--- a/lib/zoi/iso/naive_datetime.ex
+++ b/lib/zoi/iso/naive_datetime.ex
@@ -3,6 +3,7 @@ defmodule Zoi.ISO.NaiveDateTime do
   use Zoi.Type.Def
 
   def new(opts \\ []) do
+    opts = Keyword.merge([error: "invalid type: must be an ISO naive datetime"], opts)
     apply_type(opts)
   end
 
@@ -22,7 +23,7 @@ defmodule Zoi.ISO.NaiveDateTime do
     end
 
     defp error(schema) do
-      {:error, schema.meta.error || "invalid type: must be an ISO naive datetime"}
+      {:error, schema.meta.error}
     end
 
     def type_spec(_schema, _opts) do

--- a/lib/zoi/iso/time.ex
+++ b/lib/zoi/iso/time.ex
@@ -3,6 +3,7 @@ defmodule Zoi.ISO.Time do
   use Zoi.Type.Def
 
   def new(opts \\ []) do
+    opts = Keyword.merge([error: "invalid type: must be an ISO time"], opts)
     apply_type(opts)
   end
 
@@ -22,7 +23,7 @@ defmodule Zoi.ISO.Time do
     end
 
     defp error(schema) do
-      {:error, schema.meta.error || "invalid type: must be an ISO time"}
+      {:error, schema.meta.error}
     end
 
     def type_spec(_schema, _opts) do

--- a/lib/zoi/types/array.ex
+++ b/lib/zoi/types/array.ex
@@ -4,6 +4,7 @@ defmodule Zoi.Types.Array do
   use Zoi.Type.Def, fields: [:inner]
 
   def new(inner, opts) do
+    opts = Keyword.merge([error: "invalid type: must be an array"], opts)
     apply_type(opts ++ [inner: inner])
   end
 
@@ -33,7 +34,7 @@ defmodule Zoi.Types.Array do
     end
 
     def parse(schema, _, _) do
-      {:error, schema.meta.error || "invalid type: must be an array"}
+      {:error, schema.meta.error}
     end
 
     def type_spec(%Zoi.Types.Array{inner: inner}, opts) do

--- a/lib/zoi/types/atom.ex
+++ b/lib/zoi/types/atom.ex
@@ -3,6 +3,7 @@ defmodule Zoi.Types.Atom do
   use Zoi.Type.Def, fields: []
 
   def new(opts \\ []) do
+    opts = Keyword.merge([error: "invalid type: must be an atom"], opts)
     apply_type(opts)
   end
 
@@ -12,7 +13,7 @@ defmodule Zoi.Types.Atom do
     end
 
     def parse(schema, _input, _opts) do
-      {:error, schema.meta.error || "invalid type: must be an atom"}
+      {:error, schema.meta.error}
     end
 
     def type_spec(_schema, _opts) do

--- a/lib/zoi/types/boolean.ex
+++ b/lib/zoi/types/boolean.ex
@@ -4,6 +4,7 @@ defmodule Zoi.Types.Boolean do
   use Zoi.Type.Def, fields: [coerce: false]
 
   def new(opts \\ []) do
+    opts = Keyword.merge([error: "invalid type: must be a boolean", coerce: false], opts)
     apply_type(opts)
   end
 
@@ -27,7 +28,7 @@ defmodule Zoi.Types.Boolean do
     end
 
     defp error(schema) do
-      {:error, schema.meta.error || "invalid type: must be a boolean"}
+      {:error, schema.meta.error}
     end
 
     def type_spec(_schema, _opts) do

--- a/lib/zoi/types/date.ex
+++ b/lib/zoi/types/date.ex
@@ -3,6 +3,7 @@ defmodule Zoi.Types.Date do
   use Zoi.Type.Def, fields: [coerce: false]
 
   def new(opts \\ []) do
+    opts = Keyword.merge([error: "invalid type: must be a date", coerce: false], opts)
     apply_type(opts)
   end
 
@@ -39,7 +40,7 @@ defmodule Zoi.Types.Date do
     end
 
     defp error(schema) do
-      {:error, schema.meta.error || "invalid type: must be a date"}
+      {:error, schema.meta.error}
     end
 
     def type_spec(_schema, _opts) do

--- a/lib/zoi/types/datetime.ex
+++ b/lib/zoi/types/datetime.ex
@@ -3,6 +3,7 @@ defmodule Zoi.Types.DateTime do
   use Zoi.Type.Def, fields: [coerce: false]
 
   def new(opts \\ []) do
+    opts = Keyword.merge([error: "invalid type: must be a datetime", coerce: false], opts)
     apply_type(opts)
   end
 
@@ -45,7 +46,7 @@ defmodule Zoi.Types.DateTime do
     end
 
     defp error(schema) do
-      {:error, schema.meta.error || "invalid type: must be a datetime"}
+      {:error, schema.meta.error}
     end
 
     def type_spec(_schema, _opts) do

--- a/lib/zoi/types/decimal.ex
+++ b/lib/zoi/types/decimal.ex
@@ -5,6 +5,7 @@ if Code.ensure_loaded?(Decimal) do
     use Zoi.Type.Def, fields: [coerce: false]
 
     def new(opts) do
+      opts = Keyword.merge([error: "invalid type: must be a decimal", coerce: false], opts)
       apply_type(opts)
     end
 
@@ -30,7 +31,7 @@ if Code.ensure_loaded?(Decimal) do
       end
 
       defp error(schema) do
-        {:error, schema.meta.error || "invalid type: must be a decimal"}
+        {:error, schema.meta.error}
       end
 
       def type_spec(_schema, _opts) do

--- a/lib/zoi/types/enum.ex
+++ b/lib/zoi/types/enum.ex
@@ -14,6 +14,10 @@ defmodule Zoi.Types.Enum do
           {value, value}
       end)
 
+    options = stringify_enum(mapping)
+
+    opts = Keyword.merge([error: "invalid option, must be one of: #{options}"], opts)
+
     apply_type(opts ++ [values: mapping, enum_type: type])
   end
 
@@ -39,6 +43,10 @@ defmodule Zoi.Types.Enum do
 
   defp verify_type(_values) do
     raise ArgumentError, "Invalid enum values"
+  end
+
+  defp stringify_enum(values) do
+    Enum.map_join(values, ", ", fn {_key, value} -> value end)
   end
 
   defimpl Zoi.Type do
@@ -76,16 +84,7 @@ defmodule Zoi.Types.Enum do
     end
 
     defp error(schema) do
-      options = stringify_enum(schema.values)
-
-      error =
-        schema.meta.error || "invalid option, must be one of: #{options}"
-
-      {:error, error}
-    end
-
-    defp stringify_enum(values) do
-      Enum.map_join(values, ", ", fn {_key, value} -> value end)
+      {:error, schema.meta.error}
     end
 
     def type_spec(%Zoi.Types.Enum{values: values} = _schema, _opts) do

--- a/lib/zoi/types/float.ex
+++ b/lib/zoi/types/float.ex
@@ -4,6 +4,7 @@ defmodule Zoi.Types.Float do
   use Zoi.Type.Def, fields: [coerce: false]
 
   def new(opts \\ []) do
+    opts = Keyword.merge([error: "invalid type: must be a float", coerce: false], opts)
     apply_type(opts)
   end
 
@@ -31,7 +32,7 @@ defmodule Zoi.Types.Float do
     end
 
     defp error(schema) do
-      {:error, schema.meta.error || "invalid type: must be a float"}
+      {:error, schema.meta.error}
     end
 
     def type_spec(_schema, _opts) do

--- a/lib/zoi/types/integer.ex
+++ b/lib/zoi/types/integer.ex
@@ -4,6 +4,7 @@ defmodule Zoi.Types.Integer do
   use Zoi.Type.Def, fields: [coerce: false]
 
   def new(opts) do
+    opts = Keyword.merge([error: "invalid type: must be an integer", coerce: false], opts)
     apply_type(opts)
   end
 
@@ -31,7 +32,7 @@ defmodule Zoi.Types.Integer do
     end
 
     defp error(schema) do
-      {:error, schema.meta.error || "invalid type: must be an integer"}
+      {:error, schema.meta.error}
     end
 
     def type_spec(_schema, _opts) do

--- a/lib/zoi/types/keyword.ex
+++ b/lib/zoi/types/keyword.ex
@@ -4,6 +4,12 @@ defmodule Zoi.Types.Keyword do
   use Zoi.Type.Def, fields: [:fields, :strict, :coerce]
 
   def new(fields, opts) when is_list(fields) do
+    opts =
+      Keyword.merge(
+        [error: "invalid type: must be a keyword list", strict: false, coerce: false],
+        opts
+      )
+
     apply_type(opts ++ [fields: fields])
   end
 
@@ -24,7 +30,7 @@ defmodule Zoi.Types.Keyword do
     end
 
     def parse(schema, _, _) do
-      {:error, schema.meta.error || "invalid type: must be a keyword list"}
+      {:error, schema.meta.error}
     end
 
     defp do_parse(

--- a/lib/zoi/types/map.ex
+++ b/lib/zoi/types/map.ex
@@ -4,6 +4,7 @@ defmodule Zoi.Types.Map do
   use Zoi.Type.Def, fields: [:key_type, :value_type]
 
   def new(key_type, value_type, opts) do
+    opts = Keyword.merge([error: "invalid type: must be a map"], opts)
     apply_type(Keyword.merge(opts, key_type: key_type, value_type: value_type))
   end
 
@@ -33,7 +34,7 @@ defmodule Zoi.Types.Map do
     end
 
     def parse(schema, _, _) do
-      {:error, schema.meta.error || "invalid type: must be a map"}
+      {:error, schema.meta.error}
     end
 
     def type_spec(%Zoi.Types.Map{key_type: key_type, value_type: value_type}, opts) do

--- a/lib/zoi/types/naive_datetime.ex
+++ b/lib/zoi/types/naive_datetime.ex
@@ -3,6 +3,7 @@ defmodule Zoi.Types.NaiveDateTime do
   use Zoi.Type.Def, fields: [coerce: false]
 
   def new(opts \\ []) do
+    opts = Keyword.merge([error: "invalid type: must be a naive datetime", coerce: false], opts)
     apply_type(opts)
   end
 
@@ -39,7 +40,7 @@ defmodule Zoi.Types.NaiveDateTime do
     end
 
     defp error(schema) do
-      {:error, schema.meta.error || "invalid type: must be a naive datetime"}
+      {:error, schema.meta.error}
     end
 
     def type_spec(_schema, _opts) do

--- a/lib/zoi/types/null.ex
+++ b/lib/zoi/types/null.ex
@@ -4,6 +4,7 @@ defmodule Zoi.Types.Null do
   use Zoi.Type.Def
 
   def new(opts \\ []) do
+    opts = Keyword.merge([error: "invalid type: must be nil"], opts)
     apply_type(opts)
   end
 
@@ -13,7 +14,7 @@ defmodule Zoi.Types.Null do
     end
 
     def parse(schema, _input, _opts) do
-      {:error, schema.meta.error || "invalid type: must be nil"}
+      {:error, schema.meta.error}
     end
 
     def type_spec(_schema, _opts) do

--- a/lib/zoi/types/nullable.ex
+++ b/lib/zoi/types/nullable.ex
@@ -4,18 +4,20 @@ defmodule Zoi.Types.Nullable do
   use Zoi.Type.Def, fields: [:inner]
 
   def new(inner, opts \\ []) do
-    apply_type(opts ++ [inner: inner])
+    opts =
+      Keyword.merge([error: "#{inner.meta.error} or nil"], opts)
+
+    apply_type(opts ++ [inner: Zoi.union([inner, Zoi.null()], opts)])
   end
 
   defimpl Zoi.Type do
-    def parse(%{inner: _schema}, nil, _opts), do: {:ok, nil}
     def parse(%{inner: schema}, value, opts), do: Zoi.parse(schema, value, opts)
 
     def type_spec(%{inner: schema}, opts) do
       inner_type = Zoi.Type.type_spec(schema, opts)
 
       quote do
-        unquote(inner_type) | nil
+        unquote(inner_type)
       end
     end
   end

--- a/lib/zoi/types/object.ex
+++ b/lib/zoi/types/object.ex
@@ -19,6 +19,9 @@ defmodule Zoi.Types.Object do
       |> Zoi.keyword(opts)
       |> Zoi.transform({__MODULE__, :__transform__, []})
 
+    opts =
+      Keyword.merge([error: "invalid type: must be a map", strict: false, coerce: false], opts)
+
     apply_type(opts ++ [fields: fields, inner: inner])
   end
 
@@ -36,7 +39,7 @@ defmodule Zoi.Types.Object do
     end
 
     def parse(schema, _, _) do
-      {:error, schema.meta.error || "invalid type: must be a map"}
+      {:error, schema.meta.error}
     end
 
     def type_spec(%Zoi.Types.Object{fields: fields}, opts) do

--- a/lib/zoi/types/string.ex
+++ b/lib/zoi/types/string.ex
@@ -2,7 +2,8 @@ defmodule Zoi.Types.String do
   @moduledoc false
   use Zoi.Type.Def, fields: [coerce: false]
 
-  def new(opts \\ []) do
+  def new(opts) do
+    opts = Keyword.merge([error: "invalid type: must be a string", coerce: false], opts)
     apply_type(opts)
   end
 
@@ -18,7 +19,7 @@ defmodule Zoi.Types.String do
           {:ok, to_string(input)}
 
         true ->
-          {:error, schema.meta.error || "invalid type: must be a string"}
+          {:error, schema.meta.error}
       end
     end
 

--- a/lib/zoi/types/string_boolean.ex
+++ b/lib/zoi/types/string_boolean.ex
@@ -4,6 +4,20 @@ defmodule Zoi.Types.StringBoolean do
   use Zoi.Type.Def, fields: [:case, :truthy, :falsy]
 
   def new(opts \\ []) do
+    truthy = ["true", "1", "yes", "on", "y", "enabled"]
+    falsy = ["false", "0", "no", "off", "n", "disabled"]
+
+    opts =
+      Keyword.merge(
+        [
+          case: "insensitive",
+          error: "invalid type: must be a string boolean",
+          truthy: truthy,
+          falsy: falsy
+        ],
+        opts
+      )
+
     apply_type(opts)
   end
 
@@ -13,17 +27,13 @@ defmodule Zoi.Types.StringBoolean do
     end
 
     def parse(schema, input, _opts) when is_binary(input) do
-      truthy = schema.truthy || ["true", "1", "yes", "on", "y", "enabled"]
-      falsy = schema.falsy || ["false", "0", "no", "off", "n", "disabled"]
-      case_sensitive = schema.case || "insensitive"
-
-      input = modify_input_case(input, case_sensitive)
+      input = modify_input_case(input, schema.case)
 
       cond do
-        input in truthy ->
+        input in schema.truthy ->
           {:ok, true}
 
-        input in falsy ->
+        input in schema.falsy ->
           {:ok, false}
 
         true ->

--- a/lib/zoi/types/time.ex
+++ b/lib/zoi/types/time.ex
@@ -3,6 +3,7 @@ defmodule Zoi.Types.Time do
   use Zoi.Type.Def, fields: [coerce: false]
 
   def new(opts \\ []) do
+    opts = Keyword.merge([error: "invalid type: must be a time", coerce: false], opts)
     apply_type(opts)
   end
 
@@ -35,7 +36,7 @@ defmodule Zoi.Types.Time do
     end
 
     defp error(schema) do
-      {:error, schema.meta.error || "invalid type: must be a time"}
+      {:error, schema.meta.error}
     end
 
     def type_spec(_schema, _opts) do

--- a/lib/zoi/types/tuple.ex
+++ b/lib/zoi/types/tuple.ex
@@ -4,7 +4,9 @@ defmodule Zoi.Types.Tuple do
 
   def new(fields, opts) when is_tuple(fields) do
     fields = Tuple.to_list(fields)
-    apply_type(Keyword.merge(opts, fields: fields, length: length(fields)))
+    length = length(fields)
+    opts = Keyword.merge([error: "invalid type: must be a tuple with #{length} elements"], opts)
+    apply_type(Keyword.merge(opts, fields: fields, length: length))
   end
 
   def new(_fields, _opts) do
@@ -52,8 +54,7 @@ defmodule Zoi.Types.Tuple do
     end
 
     defp error(schema) do
-      {:error,
-       schema.meta.error || "invalid type: must be a tuple with #{schema.length} elements"}
+      {:error, schema.meta.error}
     end
 
     def type_spec(%Zoi.Types.Tuple{fields: fields}, opts) do

--- a/test/zoi_test.exs
+++ b/test/zoi_test.exs
@@ -302,7 +302,7 @@ defmodule ZoiTest do
     test "nullable with incorrect type" do
       schema = Zoi.nullable(Zoi.string())
       assert {:error, [%Zoi.Error{} = error]} = Zoi.parse(schema, 123)
-      assert Exception.message(error) == "invalid type: must be a string"
+      assert Exception.message(error) == "invalid type: must be a string or nil"
     end
 
     test "nullable with transform" do


### PR DESCRIPTION
…ng time

`Zoi.nullable/2` now returns the error message "invalid type: must be a %{type} or nil"