### PR TITLE
fix: Array type would `append_path` instead of `add_path` on error

### DIFF
--- a/lib/zoi/error.ex
+++ b/lib/zoi/error.ex
@@ -11,10 +11,6 @@ defmodule Zoi.Error do
     struct!(__MODULE__, opts)
   end
 
-  def append_path(%__MODULE__{} = error, path) when is_list(path) do
-    %{error | path: error.path ++ path}
-  end
-
   def add_path(%__MODULE__{} = error, path) when is_list(path) do
     %{error | path: path ++ error.path}
   end

--- a/lib/zoi/types/array.ex
+++ b/lib/zoi/types/array.ex
@@ -20,7 +20,7 @@ defmodule Zoi.Types.Array do
             {[value | parsed], errors}
 
           {:error, err} ->
-            error = Enum.map(err, &Zoi.Error.append_path(&1, [index]))
+            error = Enum.map(err, &Zoi.Error.add_path(&1, [index]))
             {parsed, Zoi.Errors.merge(errors, error)}
         end
       end)

--- a/test/zoi_test.exs
+++ b/test/zoi_test.exs
@@ -1112,7 +1112,13 @@ defmodule ZoiTest do
                Zoi.parse(schema, [[1, 2], ["not an integer", 4]])
 
       assert Exception.message(error) == "invalid type: must be an integer"
-      assert error.path == [0, 1]
+      assert error.path == [1, 0]
+
+      assert {:error, [%Zoi.Error{} = error]} =
+               Zoi.parse(schema, [[1, 2], [3, "not an integer"]])
+
+      assert Exception.message(error) == "invalid type: must be an integer"
+      assert error.path == [1, 1]
     end
 
     test "array with deeply nested arrays" do


### PR DESCRIPTION
The error path during array failure was wrong.

All other types seems to call `add_path` (which should probably be called `prepend_path`) on their way out of nested parsing, so I suspect that to be the correct behaviour.

Array was the only one using `append_path`, so I've removed `append_path`.

I also fixed a test that asserted the wrong path.
This is what gave it away, the path in the test was not pointing to the actual error element of the data.