### PR TITLE
fix decimal type being required dependency on `Zoi.Describe` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Fix nested `Zoi.keyword/2` error when parsing invalid values
+- Fix `Zoi.Describe` when dealing with `Decimal` optional dependency
 
 ## 0.8.3 - 2025-10-31
 

--- a/lib/zoi/describe.ex
+++ b/lib/zoi/describe.ex
@@ -109,7 +109,11 @@ defmodule Zoi.Describe do
   defp parse_type_spec(%Zoi.Types.Boolean{}), do: "`t:boolean/0`"
   defp parse_type_spec(%Zoi.Types.Date{}), do: "`t:Date.t/0`"
   defp parse_type_spec(%Zoi.Types.DateTime{}), do: "`t:DateTime.t/0`"
-  defp parse_type_spec(%Zoi.Types.Decimal{}), do: "`t:Decimal.t/0`"
+
+  if Code.ensure_loaded?(Decimal) do
+    defp parse_type_spec(%Zoi.Types.Decimal{}), do: "`t:Decimal.t/0`"
+  end
+
   defp parse_type_spec(%Zoi.Types.Default{inner: inner}), do: parse_type_spec(inner)
 
   defp parse_type_spec(%Zoi.Types.Enum{values: values}),


### PR DESCRIPTION
https://github.com/phcurado/zoi/issues/84