### PR TITLE
Add coerce option from strings to Atom

### DIFF
--- a/lib/zoi/types/atom.ex
+++ b/lib/zoi/types/atom.ex
@@ -1,10 +1,11 @@
 defmodule Zoi.Types.Atom do
   @moduledoc false
 
-  use Zoi.Type.Def
+  use Zoi.Type.Def, fields: [coerce: false]
 
   def opts() do
     Zoi.Opts.meta_opts()
+    |> Zoi.Opts.with_coerce()
   end
 
   def new(opts \\ []) do
@@ -16,7 +17,21 @@ defmodule Zoi.Types.Atom do
       {:ok, input}
     end
 
+    def parse(schema, input, opts) when is_binary(input) do
+      coerce = Keyword.get(opts, :coerce, schema.coerce)
+
+      if coerce do
+        {:ok, String.to_existing_atom(input)}
+      else
+        error(schema)
+      end
+    end
+
     def parse(schema, _, _) do
+      error(schema)
+    end
+
+    def error(schema) do
       {:error, Zoi.Error.invalid_type(:atom, error: schema.meta.error)}
     end
 


### PR DESCRIPTION
Earlier, I encountered an error while using the library when attempting to parse a JSON object with a field declared as an atom. I was surprised to find that there’s no coerce option for atoms.

Is there a specific reason for this lack of option ? If not, here is my contribution.

Please let me know if I missed anything. :)