### PR TITLE
Infer typespec for string literal correctly

### DIFF
--- a/lib/zoi/types/literal.ex
+++ b/lib/zoi/types/literal.ex
@@ -29,6 +29,7 @@ defmodule Zoi.Types.Literal do
         false -> quote(do: false)
         _ when is_map(value) -> quote(do: map())
         _ when is_list(value) -> quote(do: list())
+        _ when is_binary(value) -> quote(do: binary())
         value -> quote(do: unquote(value))
       end
     end

--- a/test/zoi/type_spec_test.exs
+++ b/test/zoi/type_spec_test.exs
@@ -42,7 +42,7 @@ defmodule Zoi.TypeSpecTest do
         {Zoi.integer(), quote(do: integer())},
         {Zoi.intersection([Zoi.string(), Zoi.atom()]), quote(do: binary() | atom())},
         {Zoi.literal(nil), quote(do: nil)},
-        {Zoi.literal("hello"), quote(do: "hello")},
+        {Zoi.literal("hello"), quote(do: binary())},
         {Zoi.literal(1), quote(do: 1)},
         {Zoi.literal(true), quote(do: true)},
         {Zoi.literal(false), quote(do: false)},
@@ -197,11 +197,11 @@ defmodule Zoi.TypeSpecTest do
 
       # Normalize expected schemas
       cat_spec =
-        quote(do: %{required(:type) => "cat", required(:meow) => binary()})
+        quote(do: %{required(:type) => binary(), required(:meow) => binary()})
         |> normalize_map_or_struct_ast()
 
       dog_spec =
-        quote(do: %{required(:type) => "dog", required(:bark) => binary()})
+        quote(do: %{required(:type) => binary(), required(:bark) => binary()})
         |> normalize_map_or_struct_ast()
 
       # Check that both schemas are present in a union (order as it was given to discriminated_union)


### PR DESCRIPTION
Hi, just a wee fix. 🙂 

---

Typespecs do not have syntax/semantics for binary literals. "hello" is invalid in the typespecs land.