### PR TITLE
fix: encode Zoi.any as unconstrained JSON Schema

### DIFF
--- a/lib/zoi/json_schema.ex
+++ b/lib/zoi/json_schema.ex
@@ -39,6 +39,7 @@ defmodule Zoi.JSONSchema do
   | `Zoi.decimal/1` | `"number"` |
   | `Zoi.boolean/1` | `"boolean"` |
   | `Zoi.null/1` | `"null"` |
+  | `Zoi.any/1` | unconstrained schema (`{}`) |
   | `Zoi.literal/2` | `const` |
   | `Zoi.enum/2` | `enum` |
   | `Zoi.array/2` | `"array"` |

--- a/lib/zoi/types/any.ex
+++ b/lib/zoi/types/any.ex
@@ -26,6 +26,10 @@ defmodule Zoi.Types.Any do
     end
   end
 
+  defimpl Zoi.JSONSchema.Encoder do
+    def encode(_schema), do: %{}
+  end
+
   defimpl Zoi.Describe.Encoder do
     def encode(_schema), do: "`t:term/0`"
   end

--- a/test/zoi/json_schema_test.exs
+++ b/test/zoi/json_schema_test.exs
@@ -43,41 +43,6 @@ defmodule Zoi.JSONSchemaTest do
       end)
     end
 
-    test "encoding any as required and optional nested fields" do
-      schema =
-        Zoi.map(%{
-          required: Zoi.any(description: "Required open value"),
-          optional: Zoi.any(description: "Optional open value") |> Zoi.optional()
-        })
-
-      assert Zoi.to_json_schema(schema) == %{
-               "$schema": @draft,
-               type: :object,
-               properties: %{
-                 required: %{description: "Required open value"},
-                 optional: %{description: "Optional open value"}
-               },
-               required: [:required],
-               additionalProperties: true
-             }
-    end
-
-    test "encoding any preserves metadata and defaults" do
-      schema =
-        Zoi.any(
-          description: "Any JSON value",
-          metadata: [title: "Open value"]
-        )
-        |> Zoi.default(%{"accepted" => true})
-
-      assert Zoi.to_json_schema(schema) == %{
-               "$schema": @draft,
-               description: "Any JSON value",
-               title: "Open value",
-               default: %{"accepted" => true}
-             }
-    end
-
     test "enconding object" do
       schema =
         Zoi.map(%{name: Zoi.string(), age: Zoi.integer(), valid: Zoi.optional(Zoi.boolean())})
@@ -811,7 +776,6 @@ defmodule Zoi.JSONSchemaTest do
 
       assert {:ok, "anything"} = Zoi.parse(schema, "anything")
       assert {:ok, 42} = Zoi.parse(schema, 42)
-      assert Zoi.to_json_schema(schema) == %{"$schema": @draft}
     end
 
     test "string format uuid decodes to Zoi.uuid" do

--- a/test/zoi/json_schema_test.exs
+++ b/test/zoi/json_schema_test.exs
@@ -17,6 +17,7 @@ defmodule Zoi.JSONSchemaTest do
         {Zoi.boolean(), %{type: :boolean}},
         {Zoi.literal("fixed"), %{const: "fixed"}},
         {Zoi.null(), %{type: :null}},
+        {Zoi.any(), %{}},
         {Zoi.array(Zoi.integer()), %{type: :array, items: %{type: :integer}}},
         {Zoi.array(), %{type: :array}},
         {Zoi.map_set(Zoi.integer()),
@@ -40,6 +41,41 @@ defmodule Zoi.JSONSchemaTest do
         expected = Map.put(expected, :"$schema", @draft)
         assert Zoi.to_json_schema(schema) == expected
       end)
+    end
+
+    test "encoding any as required and optional nested fields" do
+      schema =
+        Zoi.map(%{
+          required: Zoi.any(description: "Required open value"),
+          optional: Zoi.any(description: "Optional open value") |> Zoi.optional()
+        })
+
+      assert Zoi.to_json_schema(schema) == %{
+               "$schema": @draft,
+               type: :object,
+               properties: %{
+                 required: %{description: "Required open value"},
+                 optional: %{description: "Optional open value"}
+               },
+               required: [:required],
+               additionalProperties: true
+             }
+    end
+
+    test "encoding any preserves metadata and defaults" do
+      schema =
+        Zoi.any(
+          description: "Any JSON value",
+          metadata: [title: "Open value"]
+        )
+        |> Zoi.default(%{"accepted" => true})
+
+      assert Zoi.to_json_schema(schema) == %{
+               "$schema": @draft,
+               description: "Any JSON value",
+               title: "Open value",
+               default: %{"accepted" => true}
+             }
     end
 
     test "enconding object" do
@@ -775,6 +811,7 @@ defmodule Zoi.JSONSchemaTest do
 
       assert {:ok, "anything"} = Zoi.parse(schema, "anything")
       assert {:ok, 42} = Zoi.parse(schema, 42)
+      assert Zoi.to_json_schema(schema) == %{"$schema": @draft}
     end
 
     test "string format uuid decodes to Zoi.uuid" do


### PR DESCRIPTION
## Summary

- implement JSON Schema encoding for `Zoi.any/1` as the unconstrained schema `{}`
- preserve existing metadata and default handling through the shared encoding pipeline
- document the type mapping and cover direct, nested optional, metadata, default, and decode/re-encode behavior

## Why

An empty JSON Schema object accepts any valid JSON value. Zoi already decodes an unconstrained schema to `Zoi.any/1`, but encoding the same type currently falls through to the unsupported-schema exception. This completes that round trip and allows `Zoi.any/1` fields to be projected in action and API schemas.

## Validation

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test`: 181 doctests and 793 tests, 0 failures
- `mix credo --strict`: 0 issues
- `mix dialyzer`: 0 errors
