### PR TITLE
Preserve child refinements in composite JSON schema encoders

### DIFF
--- a/lib/zoi/types/discriminated_union.ex
+++ b/lib/zoi/types/discriminated_union.ex
@@ -142,7 +142,7 @@ defmodule Zoi.Types.DiscriminatedUnion do
       one_of_schemas =
         schema.values
         |> Enum.map(&Map.get(schema.schemas, &1))
-        |> Enum.map(&Zoi.JSONSchema.Encoder.encode/1)
+        |> Enum.map(&Zoi.JSONSchema.encode_schema/1)
 
       %{
         oneOf: one_of_schemas,

--- a/lib/zoi/types/intersection.ex
+++ b/lib/zoi/types/intersection.ex
@@ -68,7 +68,7 @@ defmodule Zoi.Types.Intersection do
 
   defimpl Zoi.JSONSchema.Encoder do
     def encode(schema) do
-      %{allOf: Enum.map(schema.schemas, &Zoi.JSONSchema.Encoder.encode/1)}
+      %{allOf: Enum.map(schema.schemas, &Zoi.JSONSchema.encode_schema/1)}
     end
   end
 

--- a/lib/zoi/types/tuple.ex
+++ b/lib/zoi/types/tuple.ex
@@ -84,7 +84,7 @@ defmodule Zoi.Types.Tuple do
     def encode(schema) do
       %{
         type: :array,
-        prefixItems: Enum.map(schema.fields, &Zoi.JSONSchema.Encoder.encode/1)
+        prefixItems: Enum.map(schema.fields, &Zoi.JSONSchema.encode_schema/1)
       }
     end
   end

--- a/lib/zoi/types/union.ex
+++ b/lib/zoi/types/union.ex
@@ -67,7 +67,7 @@ defmodule Zoi.Types.Union do
 
   defimpl Zoi.JSONSchema.Encoder do
     def encode(schema) do
-      %{anyOf: Enum.map(schema.schemas, &Zoi.JSONSchema.Encoder.encode/1)}
+      %{anyOf: Enum.map(schema.schemas, &Zoi.JSONSchema.encode_schema/1)}
     end
   end
 

--- a/test/zoi/json_schema_test.exs
+++ b/test/zoi/json_schema_test.exs
@@ -256,21 +256,6 @@ defmodule Zoi.JSONSchemaTest do
              } = Zoi.to_json_schema(Zoi.tuple({code, Zoi.integer()}))
     end
 
-    test "discriminated_union branches keep string pattern refinements" do
-      pattern = "^[a-z]+$"
-      code = Zoi.regex(Zoi.string(), ~r/^[a-z]+$/)
-      cat_schema = Zoi.map(%{type: Zoi.literal("cat"), code: code})
-      dog_schema = Zoi.map(%{type: Zoi.literal("dog"), bark: Zoi.string()})
-
-      assert %{
-               "$schema": @draft,
-               oneOf: [cat_json_schema, _dog_json_schema],
-               discriminator: %{propertyName: "type"}
-             } = Zoi.to_json_schema(Zoi.discriminated_union(:type, [cat_schema, dog_schema]))
-
-      assert %{properties: %{code: %{type: :string, pattern: ^pattern}}} = cat_json_schema
-    end
-
     test "encoding string refinements with transforms" do
       schema =
         Zoi.string()

--- a/test/zoi/json_schema_test.exs
+++ b/test/zoi/json_schema_test.exs
@@ -220,6 +220,57 @@ defmodule Zoi.JSONSchemaTest do
       end)
     end
 
+    test "union branches keep string pattern refinements" do
+      pattern = "^[a-z]+$"
+      code = Zoi.regex(Zoi.string(), ~r/^[a-z]+$/)
+
+      assert %{
+               "$schema": @draft,
+               anyOf: [%{type: :null}, %{type: :string, pattern: ^pattern}]
+             } = Zoi.to_json_schema(Zoi.nullable(code))
+
+      assert %{
+               "$schema": @draft,
+               anyOf: [%{type: :string, pattern: ^pattern}, %{type: :integer}]
+             } = Zoi.to_json_schema(Zoi.union([code, Zoi.integer()]))
+    end
+
+    test "intersection branches keep string pattern refinements" do
+      pattern = "^[a-z]+$"
+      code = Zoi.regex(Zoi.string(), ~r/^[a-z]+$/)
+
+      assert %{
+               "$schema": @draft,
+               allOf: [%{type: :string, pattern: ^pattern}, %{type: :string}]
+             } = Zoi.to_json_schema(Zoi.intersection([code, Zoi.string()]))
+    end
+
+    test "tuple prefix items keep string pattern refinements" do
+      pattern = "^[a-z]+$"
+      code = Zoi.regex(Zoi.string(), ~r/^[a-z]+$/)
+
+      assert %{
+               "$schema": @draft,
+               type: :array,
+               prefixItems: [%{type: :string, pattern: ^pattern}, %{type: :integer}]
+             } = Zoi.to_json_schema(Zoi.tuple({code, Zoi.integer()}))
+    end
+
+    test "discriminated_union branches keep string pattern refinements" do
+      pattern = "^[a-z]+$"
+      code = Zoi.regex(Zoi.string(), ~r/^[a-z]+$/)
+      cat_schema = Zoi.map(%{type: Zoi.literal("cat"), code: code})
+      dog_schema = Zoi.map(%{type: Zoi.literal("dog"), bark: Zoi.string()})
+
+      assert %{
+               "$schema": @draft,
+               oneOf: [cat_json_schema, _dog_json_schema],
+               discriminator: %{propertyName: "type"}
+             } = Zoi.to_json_schema(Zoi.discriminated_union(:type, [cat_schema, dog_schema]))
+
+      assert %{properties: %{code: %{type: :string, pattern: ^pattern}}} = cat_json_schema
+    end
+
     test "encoding string refinements with transforms" do
       schema =
         Zoi.string()


### PR DESCRIPTION
Closes #183

### Problem
`Zoi.to_json_schema/1` silently drops effect refinements (e.g. `Zoi.regex/2` → `pattern`) from child schemas nested inside composite types. A constraint present at the top level disappears once wrapped in `nullable`/`union`/etc., which is surprising given that struct-level constraints like `min_length` survive.

```elixir
Zoi.to_json_schema(Zoi.regex(Zoi.string(), ~r/^[a-z]+$/))
#=> %{type: :string, pattern: "^[a-z]+$"}          # ✅

Zoi.to_json_schema(Zoi.nullable(Zoi.regex(Zoi.string(), ~r/^[a-z]+$/)))
#=> %{anyOf: [%{type: :null}, %{type: :string}]}   # ❌ pattern dropped
```

### Root cause
Refinements are only attached by `Zoi.JSONSchema.encode_schema/1` (via `encode_refinements/2`). The composite encoders map their children through the raw protocol `Zoi.JSONSchema.Encoder.encode/1`, which skips `encode_metadata/2` + `encode_refinements/2`.

### Fix
Encode children via `Zoi.JSONSchema.encode_schema/1` instead. It does not add the `$schema` dialect (top-level only), so branches gain `pattern`/metadata without a stray `$schema`. Applied to all four affected encoders:

- `union` (`anyOf`, covers `nullable`)
- `intersection` (`allOf`)
- `tuple` (`prefixItems`)
- `discriminated_union` (`oneOf`)

### Tests
Added one test per fixed encoder in `test/zoi/json_schema_test.exs` asserting a nested regex `pattern` is preserved. Each fails before the change and passes after.

Full suite: `181 doctests, 795 tests, 0 failures`.
